### PR TITLE
GHC 8.0 doesn't export replaceDynFlags

### DIFF
--- a/src/Argon/Preprocess.hs
+++ b/src/Argon/Preprocess.hs
@@ -19,6 +19,7 @@ import qualified DynFlags       as GHC
 import qualified MonadUtils     as GHC
 import qualified DriverPhases   as GHC
 import qualified DriverPipeline as GHC
+import qualified HscTypes       as GHC
 
 data CppOptions = CppOptions
                 { cppDefine :: [String]    -- ^ CPP #define macros
@@ -36,8 +37,8 @@ getPreprocessedSrcDirect :: (GHC.GhcMonad m)
                          -> m (String, GHC.DynFlags)
 getPreprocessedSrcDirect cppOptions file = do
   hscEnv <- GHC.getSession
-  let dfs = GHC.extractDynFlags hscEnv
-      newEnv = GHC.replaceDynFlags hscEnv (injectCppOptions cppOptions dfs)
+  let dfs = GHC.hsc_dflags hscEnv
+      newEnv = hscEnv { GHC.hsc_dflags = injectCppOptions cppOptions dfs }
   (dflags', hspp_fn) <-
       GHC.liftIO $ GHC.preprocess newEnv (file, Just (GHC.Cpp GHC.HsSrcFile))
   txt <- GHC.liftIO $ readFile hspp_fn


### PR DESCRIPTION
In https://github.com/ghc/ghc/commit/9d30644100e636966cf4c2c921e72783bec8e299#diff-0d92703213de86fca20f780beaef4f31, I deleted `DynFlags.replaceDynFlags` from the GHC api, because it didn't really do anything and I don't like unnecessary abstractions. Turns out `argon` did use it, so here's a pull request. Should be forward and backward compatible.

