### PR TITLE
Added support for guards in Argon

### DIFF
--- a/src/Argon/Visitor.hs
+++ b/src/Argon/Visitor.hs
@@ -40,10 +40,16 @@ complexity :: Function -> Int
 complexity f = let matches = getMatches f
                    query = everythingStaged Parser (+) 0 $ 0 `mkQ` visit
                    visit = uncurry (+) . (visitExp &&& visitOp)
-                in length matches + sumWith query matches
+                in length matches + sumWith getGRHSsFromMatch matches + sumWith query matches
 
 getMatches :: Function -> [GHC.LMatch GHC.RdrName MatchBody]
 getMatches = GHC.unLoc . GHC.mg_alts . GHC.fun_matches
+
+getGRHSsFromMatch :: GHC.LMatch GHC.RdrName MatchBody -> Int
+getGRHSsFromMatch match = length (getGRHSs' match) - 1
+  where
+    getGRHSs' :: GHC.LMatch GHC.RdrName MatchBody -> [GHC.LGRHS GHC.RdrName MatchBody]
+    getGRHSs' = GHC.grhssGRHSs . GHC.m_grhss . GHC.unLoc
 
 getName :: GHC.RdrName -> String
 getName = GHC.occNameString . GHC.rdrNameOcc


### PR DESCRIPTION
As per issue #35, adds functionality to detect guarded statements in Haskell. For example, the below function now displays the correct cyclomatic complexity of 4, instead of 2:

```
nthElement :: [a] -> Int -> Maybe a 
nthElement [] a = Nothing
nthElement (x:xs) a | a <= 0 = Nothing
                    | a == 1 = Just x
                    | a > 1 = nthElement xs (a-1)
```